### PR TITLE
Enable the engine to access global scope

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1,16 +1,49 @@
+/*global window:false*/
 'use strict';
 
 var hmdajson = require('./lib/hmdajson'),
     _ = require('underscore');
 
-var Engine = function() {
-    var engine = {};
+(function() {
 
-    engine.fileToJson = function(file, spec, next) {
-        return hmdajson.process(file, spec, next);
+    // Set root (global) scope
+    var root = this;
+
+    root._HMDA_JSON = null;
+
+    // Constructor of our HMDAEngine
+    var HMDAEngine = function(obj) {
+        if (obj instanceof HMDAEngine) {
+            return obj;
+        }
+        if (!(this instanceof HMDAEngine)) {
+            return new HMDAEngine(obj);
+        }
     };
 
-    engine.hasRecordIdentifiersForEachRow = function(hmdaFile) {
+    // Set the HMDAEngine as either the exported module for
+    // CommonJS (node) or on the root scope (for browsers)
+    if (typeof exports !== 'undefined') {
+        if (typeof module !== 'undefined' && module.exports) {
+            exports = module.exports = HMDAEngine;
+        }
+        exports.HMDAEngine = HMDAEngine;
+    } else {
+        root.HMDAEngine = HMDAEngine;
+    }
+
+    //-----------------------------------------------------//
+
+    HMDAEngine.fileToJson = function(file, spec, next) {
+        hmdajson.process(file, spec, function(err, result) {
+            if (! err && result) {
+                root._HMDA_JSON = result;
+            }
+            next(err, root._HMDA_JSON);
+        });
+    };
+
+    HMDAEngine.hasRecordIdentifiersForEachRow = function(hmdaFile) {
         if (hmdaFile.transmittalSheet.recordID !== '1') {
             return false;
         } else {
@@ -23,11 +56,11 @@ var Engine = function() {
         return true;
     };
 
-    engine.hasAtLeastOneLAR = function(hmdaFile) {
+    HMDAEngine.hasAtLeastOneLAR = function(hmdaFile) {
         return hmdaFile.loanApplicationRegisters.length > 0;
     };
 
-    engine.isValidAgencyCode = function(hmdaFile) {
+    HMDAEngine.isValidAgencyCode = function(hmdaFile) {
         var validAgencies = [1, 2, 3, 5, 7, 9];
         if (! _.contains(validAgencies, hmdaFile.transmittalSheet.agencyCode)) {
             return false;
@@ -42,11 +75,11 @@ var Engine = function() {
         return true;
     };
 
-    engine.hasUniqueLoanNumbers = function(hmdaFile) {
+    HMDAEngine.hasUniqueLoanNumbers = function(hmdaFile) {
         return _.unique(hmdaFile.loanApplicationRegisters, _.iteratee('loanNumber')).length === hmdaFile.loanApplicationRegisters.length;
     };
 
-    return engine;
-};
-
-module.exports = new Engine();
+}.call((function() {
+  return (typeof module !== 'undefined' && module.exports &&
+    typeof window === 'undefined') ? global : window;
+}())));


### PR DESCRIPTION
This allows the engine to access global scope either via 'global' in node, or 'window' in the browser. This will be necessary for cfpb/hmda-pilot#21 due to the fact that after parsing the rules from the spec language into runnable code (_rules-as-code_) it will only have access to global scope. This allows us to set the HMDA file that is parsed into JSON (`_HMDA_JSON`) in the global scope so that the _rules-as-code_ has access.

The engine itself becomes global as well, as `HMDAEngine`.
