### PR TITLE
Integrate sync-request and a mocked API server so we can make API calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,15 @@
     "istanbul": "^0.2.10",
     "mocha": "^1.18.0",
     "must": "^0.12.0",
-    "spec-xunit-file": "0.0.1-2",
-    "rewire": "2.1.3"
+    "rewire": "2.1.3",
+    "shmock": "^0.7.1",
+    "spec-xunit-file": "0.0.1-2"
   },
   "dependencies": {
     "brij-spec": "0.0.4",
     "hmda-rule-spec": "cfpb/hmda-rule-spec#milestone4",
     "line-chomper": "^0.4.5",
+    "sync-request": "^2.0.0",
     "underscore": "^1.7.0"
   }
 }

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -5,3 +5,30 @@
 global.expect = require('must');
 global.rewire = require('rewire');
 global._ = require('underscore');
+global.port = 0;
+
+var child = require('child_process').fork(__dirname + '/server.js');
+
+child.on('message', function(m) {
+    if (m.hasOwnProperty('port')) {
+        port = m.port;
+    };
+});
+
+global.mockAPI = function(method, path, status, reply) {
+    var ob = {
+        method: method || '',
+        path: path || '',
+        status: status || 200,
+        reply: reply || ''
+    }
+    child.send(ob);
+};
+
+before(function() {
+    mockAPI('port');
+});
+
+after(function() {
+    child.kill();
+});

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,19 @@
+var shmock = require('shmock');
+
+var mockAPI = shmock();
+
+process.on('message', function(msg) {
+    switch(msg.method) {
+        case 'port':
+            var port = mockAPI.address().port;
+            var ob = {port: port};
+            process.send(ob);
+            break;
+        case 'get':
+            mockAPI.get(msg.path).reply(msg.status, msg.reply);
+            break;
+        case 'clean':
+            mockAPI.clean();
+            break;
+    }
+});


### PR DESCRIPTION
This will close cfpb/hmda-pilot#179 for now. Synchronous requests are slower, so this may need to be revisited to make sure that everything is processed asynchronously.

This forks off `shmock` mocking server so it gets it's own event loop in the `bootstrap.js`
Implementation of engine function `isChildFI` included as example of how to use `sync-request` for API calls, and tests added to show how to mock out the `get` that needs to respond.