### PR TITLE
Add in persist support to shmock

### DIFF
--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -9,12 +9,13 @@ global.port = 0;
 
 var child = require('child_process').fork(__dirname + '/server.js');
 
-global.mockAPI = function(method, path, status, reply) {
+global.mockAPI = function(method, path, status, reply, persisted) {
     var ob = {
-        method: method || '',
-        path: path || '',
+        method: method || 'get',
+        path: path || '/',
         status: status || 200,
-        reply: reply || ''
+        reply: reply || '{}',
+        persisted: persisted || false
     }
     child.send(ob);
 };

--- a/test/engineSpec.js
+++ b/test/engineSpec.js
@@ -30,17 +30,25 @@ describe('Engine', function() {
     });
 
     describe('Make sure mockAPI is up', function() {
-        it('should allow route define and respond with 200', function(done) {
+        it('should allow route define and respond with 200 first time, 404 second time called', function(done) {
             mockAPI('get', '/foo', 200, 'bar');
             http.get(mockAPIURL+'/foo', function(resp) {
                 expect(resp.statusCode).to.be(200);
-                done();
+                http.get(mockAPIURL+'/foo', function(resp) {
+                    expect(resp.statusCode).to.be(404);
+                    done();
+                });
             });
         });
-        it('should have fulfilled route in previus test and now respond with 404', function(done) {
-            http.get(mockAPIURL+'/foo', function(resp) {
-                expect(resp.statusCode).to.be(404);
-                done();
+
+        it('should allow route define and respond with 200 every time called when persist option enabled', function(done) {
+            mockAPI('get', '/bar', 200, 'foo', true);
+            http.get(mockAPIURL+'/bar', function(resp) {
+                expect(resp.statusCode).to.be(200);
+                http.get(mockAPIURL+'/bar', function(resp) {
+                    expect(resp.statusCode).to.be(200);
+                    done();
+                });
             });
         });
     });

--- a/test/server.js
+++ b/test/server.js
@@ -10,7 +10,11 @@ process.on('message', function(msg) {
             process.send(ob);
             break;
         case 'get':
-            mockAPI.get(msg.path).reply(msg.status, msg.reply);
+            if (msg.persisted) {
+                mockAPI.get(msg.path).persist().reply(msg.status, msg.reply);
+            } else {
+                mockAPI.get(msg.path).reply(msg.status, msg.reply);
+            }
             break;
         case 'clean':
             mockAPI.clean();


### PR DESCRIPTION
For cfpb/hmda-pilot#179 and tests
This should allow shmock to answer to the same route multiple times with the same reply during a test.

@porterbot The test in `engineSpec.js` line **44** shows how it works.. just pass an additional `true` to `mockAPI` to persist the route for the duration of the test.