### PR TITLE
Make sure that any error with a lar gets loanNumber

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -48,7 +48,9 @@ var handleArrayErrors = function(hmdaFile, lines, properties) {
         if (line === 1) {
             retrieveProps(error, hmdaFile.transmittalSheet, properties);
         } else {
-            retrieveProps(error, hmdaFile.loanApplicationRegisters[line-2], properties);
+            var lar = hmdaFile.loanApplicationRegisters[line-2];
+            retrieveProps(error, lar, properties);
+            error.loanNumber = lar.loanNumber;
         }
         errors.push(error);
     }
@@ -822,6 +824,9 @@ var resolveError = function(err) {
                 var error = {'properties': {}};
 
                 error.lineNumber = topLevelObj.lineNumber;
+                if (topLevelObj.hasOwnProperty('loanNumber')) {
+                    error.loanNumber = topLevelObj.loanNumber;
+                }
                 for (var i = 0; i < args.length; i++) {
                     error.properties[result.args[i]] = args[i];
                 }

--- a/test/testdata/array-errors.json
+++ b/test/testdata/array-errors.json
@@ -11,6 +11,7 @@
 		"properties": {
 			"recordID": "2",
 			"filler": "B"
-		}
+		},
+		"loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
 	}
 ]

--- a/test/testdata/errors-quality.json
+++ b/test/testdata/errors-quality.json
@@ -33,7 +33,8 @@
                         "applicantSex": "1",
                         "applicationReceivedDate": "20130117",
                         "actionTaken": "5"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "3",
@@ -43,7 +44,8 @@
                         "applicantSex": "1",
                         "applicationReceivedDate": "20130117",
                         "actionTaken": "5"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "4",
@@ -53,7 +55,8 @@
                         "applicantSex": "1",
                         "applicationReceivedDate": "20130117",
                         "actionTaken": "5"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 }
             ]
         },
@@ -66,19 +69,22 @@
                     "lineNumber": "2",
                     "properties": {
                         "applicantIncome": "9000"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "3",
                     "properties": {
                         "applicantIncome": "9000"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "4",
                     "properties": {
                         "applicantIncome": "9000"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 }
             ]
         },
@@ -92,21 +98,24 @@
                     "properties": {
                         "loanType": "4",
                         "propertyType": "3"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "3",
                     "properties": {
                         "loanType": "4",
                         "propertyType": "3"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "4",
                     "properties": {
                         "loanType": "4",
                         "propertyType": "3"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 }
             ]
         }

--- a/test/testdata/errors-syntactical.json
+++ b/test/testdata/errors-syntactical.json
@@ -36,21 +36,24 @@
                     "properties": {
                         "actionDate": "20130119",
                         "hmdaFile.transmittalSheet.activityYear": "2014"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "3",
                     "properties": {
                         "actionDate": "20130119",
                         "hmdaFile.transmittalSheet.activityYear": "2014"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "4",
                     "properties": {
                         "actionDate": "20130119",
                         "hmdaFile.transmittalSheet.activityYear": "2014"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 }
             ]
         },

--- a/test/testdata/errors-validity.json
+++ b/test/testdata/errors-validity.json
@@ -23,7 +23,8 @@
                     "lineNumber": "3",
                     "properties": {
                         "preapprovals": " "
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 }
             ]
         },
@@ -37,21 +38,24 @@
                     "properties": {
                         "loanPurpose": "2",
                         "preapprovals": "1"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "3",
                     "properties": {
                         "loanPurpose": "2",
                         "preapprovals": " "
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "4",
                     "properties": {
                         "loanPurpose": "2",
                         "preapprovals": "1"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 }
             ]
         },
@@ -67,7 +71,8 @@
                         "denialReason2": "8",
                         "denialReason3": "7",
                         "actionTaken": "5"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "3",
@@ -76,7 +81,8 @@
                         "denialReason2": "8",
                         "denialReason3": "7",
                         "actionTaken": "5"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "4",
@@ -85,7 +91,8 @@
                         "denialReason2": "8",
                         "denialReason3": "7",
                         "actionTaken": "5"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 }
             ]
         },
@@ -102,7 +109,8 @@
                         "applicantRace3": "3",
                         "applicantRace4": "2",
                         "applicantRace5": "1"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "3",
@@ -112,7 +120,8 @@
                         "applicantRace3": "3",
                         "applicantRace4": "2",
                         "applicantRace5": "1"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "4",
@@ -122,7 +131,8 @@
                         "applicantRace3": "3",
                         "applicantRace4": "2",
                         "applicantRace5": "1"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 }
             ]
         },
@@ -139,7 +149,8 @@
                         "coapplicantRace3": "6",
                         "coapplicantRace4": "5",
                         "coapplicantRace5": "4"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "3",
@@ -149,7 +160,8 @@
                         "coapplicantRace3": "6",
                         "coapplicantRace4": "5",
                         "coapplicantRace5": "4"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "4",
@@ -159,7 +171,8 @@
                         "coapplicantRace3": "6",
                         "coapplicantRace4": "5",
                         "coapplicantRace5": "4"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 }
             ]
         },
@@ -174,7 +187,8 @@
                         "coapplicantEthnicity": "5",
                         "coapplicantRace1": "8",
                         "coapplicantSex": "2"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "3",
@@ -182,7 +196,8 @@
                         "coapplicantEthnicity": "5",
                         "coapplicantRace1": "8",
                         "coapplicantSex": "2"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "4",
@@ -190,8 +205,9 @@
                         "coapplicantEthnicity": "5",
                         "coapplicantRace1": "8",
                         "coapplicantSex": "2"
-                    }
-                }    
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
+                }
             ]
         },
         "V335": {
@@ -204,21 +220,24 @@
                     "properties": {
                         "propertyType": "3",
                         "applicantIncome": "9000"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "3",
                     "properties": {
                         "propertyType": "3",
                         "applicantIncome": "9000"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "4",
                     "properties": {
                         "propertyType": "3",
                         "applicantIncome": "9000"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 }
             ]
         },
@@ -232,21 +251,24 @@
                     "properties": {
                         "actionTaken": "5",
                         "rateSpread": "01.05"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "3",
                     "properties": {
                         "actionTaken": "5",
                         "rateSpread": "01.05"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "4",
                     "properties": {
                         "actionTaken": "5",
                         "rateSpread": "01.05"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 }
             ]
         },
@@ -260,21 +282,24 @@
                     "properties": {
                         "actionTaken": "5",
                         "lienStatus": "4"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "3",
                     "properties": {
                         "actionTaken": "5",
                         "lienStatus": "4"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
                 {
                     "lineNumber": "4",
                     "properties": {
                         "actionTaken": "5",
                         "lienStatus": "4"
-                    }
+                    },
+                    "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 }
             ]
         }


### PR DESCRIPTION
When working through how to handle errors for Macros, noticed that we don't currently include loanNumber for LARs like we should.