### PR TITLE
Reducing the creation of unnecessary hidden classes in V8

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -64,7 +64,7 @@
     // Whether `== null` comparisons should be allowed, even if `eqeqeq` is `true`.
     "eqnull": false,
     // Whether `eval` should be allowed.
-    "evil": false,
+    "evil": true,
     // Whether ExpressionStatement should be allowed as Programs.
     "expr": true,
     // Whether `for in` loops must filter with `hasOwnPrototype`.

--- a/lib/hmdajson.js
+++ b/lib/hmdajson.js
@@ -57,7 +57,7 @@ var HMDAJson = function() {
 
     processor.parseLine = function(type, line_spec, line) {
         var result = {};
-        result.record = new hmdaPrototypes[type];
+        result.record = (hmdaPrototypes[type] ? new hmdaPrototypes[type]() : {});
         for(var field in line_spec) {
             if (line_spec.hasOwnProperty(field) && line.length >= line_spec[field].end) {
                 var value = line.slice(line_spec[field].start-1, line_spec[field].end);
@@ -88,12 +88,11 @@ var HMDAJson = function() {
             }
             hmdaPrototypes[TYPES[i]] = new Function(protoBody);     
         }
-
         chomp(file_stream, {trim: false}, function(err, lines) {
             for (var lineIdx=0; lineIdx < lines.length; lineIdx++) {
                 var type = TYPES[lineIdx] ? TYPES[lineIdx] : TYPES[1];
                 var line_spec = file_spec[type];
-                var result = processor.parseLine(type,line_spec, lines[lineIdx]);
+                var result = processor.parseLine(type, line_spec, lines[lineIdx]);
                 if (result.error) {
                     error = 'Error parsing ' + type + ' at line: ' + (lineIdx+1) + ' - ' + result.error;
                     return next(error, null);

--- a/lib/hmdajson.js
+++ b/lib/hmdajson.js
@@ -33,6 +33,48 @@ var checkParams = function(file_stream, file_spec) {
 
 var HMDAJson = function() {
     var processor = {};
+    function LAR() {
+        this.recordID = "";
+        this.respondentID = "";
+        this.agencyCode = "";
+        this.loanNumber = "";
+        this.applicationReceivedDate = "";
+        this.loanType = "";
+        this.propertyType = "";
+        this.loanPurpose = "";
+        this.ownerOccupancy = "";
+        this.loanAmount = "";
+        this.preapprovals = "";
+        this.actionTaken = "";
+        this.actionDate = "";
+        this.metroArea = "";
+        this.fipsState = "";
+        this.fipsCounty = "";
+        this.censusTract = "";
+        this.applicantEthnicity = "";
+        this.coapplicantEthnicity = "";
+        this.applicantRace1 = "";
+        this.applicantRace2 = "";
+        this.applicantRace3 = "";
+        this.applicantRace4 = "";
+        this.applicantRace5 = "";
+        this.coapplicantRace1 = "";
+        this.coapplicantRace2 = "";
+        this.coapplicantRace3 = "";
+        this.coapplicantRace4 = "";
+        this.coapplicantRace5 = "";
+        this.applicantSex = "";
+        this.coapplicantSex = "";
+        this.applicantIncome = "";
+        this.purchaserType = "";
+        this.denialReason1 = "";
+        this.denialReason2 = "";
+        this.denialReason3 = "";
+        this.rateSpread = "";
+        this.hoepaStatus = "";
+        this.lienStatus = "";
+        this.filler = "";
+    }
 
     processor.resetJsonOb = function() {
         _JSONOBJ = {
@@ -54,9 +96,12 @@ var HMDAJson = function() {
         return _JSONOBJ;
     };
 
-    processor.parseLine = function(line_spec, line) {
+    processor.parseLine = function(type, line_spec, line) {
         var result = {};
         result.record = {};
+        if (type=='loanApplicationRegister') {
+             result.record = new LAR();
+        }
         for(var field in line_spec) {
             if (line_spec.hasOwnProperty(field) && line.length >= line_spec[field].end) {
                 var value = line.slice(line_spec[field].start-1, line_spec[field].end);
@@ -83,7 +128,7 @@ var HMDAJson = function() {
             for (var lineIdx=0; lineIdx < lines.length; lineIdx++) {
                 var type = TYPES[lineIdx] ? TYPES[lineIdx] : TYPES[1];
                 var line_spec = file_spec[type];
-                var result = processor.parseLine(line_spec, lines[lineIdx]);
+                var result = processor.parseLine(type,line_spec, lines[lineIdx]);
                 if (result.error) {
                     error = 'Error parsing ' + type + ' at line: ' + (lineIdx+1) + ' - ' + result.error;
                     return next(error, null);

--- a/lib/hmdajson.js
+++ b/lib/hmdajson.js
@@ -33,48 +33,7 @@ var checkParams = function(file_stream, file_spec) {
 
 var HMDAJson = function() {
     var processor = {};
-    function LAR() {
-        this.recordID = "";
-        this.respondentID = "";
-        this.agencyCode = "";
-        this.loanNumber = "";
-        this.applicationReceivedDate = "";
-        this.loanType = "";
-        this.propertyType = "";
-        this.loanPurpose = "";
-        this.ownerOccupancy = "";
-        this.loanAmount = "";
-        this.preapprovals = "";
-        this.actionTaken = "";
-        this.actionDate = "";
-        this.metroArea = "";
-        this.fipsState = "";
-        this.fipsCounty = "";
-        this.censusTract = "";
-        this.applicantEthnicity = "";
-        this.coapplicantEthnicity = "";
-        this.applicantRace1 = "";
-        this.applicantRace2 = "";
-        this.applicantRace3 = "";
-        this.applicantRace4 = "";
-        this.applicantRace5 = "";
-        this.coapplicantRace1 = "";
-        this.coapplicantRace2 = "";
-        this.coapplicantRace3 = "";
-        this.coapplicantRace4 = "";
-        this.coapplicantRace5 = "";
-        this.applicantSex = "";
-        this.coapplicantSex = "";
-        this.applicantIncome = "";
-        this.purchaserType = "";
-        this.denialReason1 = "";
-        this.denialReason2 = "";
-        this.denialReason3 = "";
-        this.rateSpread = "";
-        this.hoepaStatus = "";
-        this.lienStatus = "";
-        this.filler = "";
-    }
+    var hmdaPrototypes = {};
 
     processor.resetJsonOb = function() {
         _JSONOBJ = {
@@ -98,10 +57,7 @@ var HMDAJson = function() {
 
     processor.parseLine = function(type, line_spec, line) {
         var result = {};
-        result.record = {};
-        if (type=='loanApplicationRegister') {
-             result.record = new LAR();
-        }
+        result.record = new hmdaPrototypes[type];
         for(var field in line_spec) {
             if (line_spec.hasOwnProperty(field) && line.length >= line_spec[field].end) {
                 var value = line.slice(line_spec[field].start-1, line_spec[field].end);
@@ -124,6 +80,15 @@ var HMDAJson = function() {
             return next(error, null);
         }
         processor.resetJsonOb();
+        for (var i=0; i<TYPES.length; i++) {
+            var line_spec = file_spec[TYPES[i]];
+            var protoBody = '';
+            for (var field in line_spec) {
+                protoBody += 'this.' + field + '="";';
+            }
+            hmdaPrototypes[TYPES[i]] = new Function(protoBody);     
+        }
+
         chomp(file_stream, {trim: false}, function(err, lines) {
             for (var lineIdx=0; lineIdx < lines.length; lineIdx++) {
                 var type = TYPES[lineIdx] ? TYPES[lineIdx] : TYPES[1];

--- a/test/lib/hmdajsonSpec.js
+++ b/test/lib/hmdajsonSpec.js
@@ -58,7 +58,7 @@ describe('lib/hmdajson', function() {
         it('should return empty record if no fields in line spec', function(done) {
             var line = '';
             var line_spec = {};
-            var result = HMDAJson.parseLine(line_spec, line).record;
+            var result = HMDAJson.parseLine('', line_spec, line).record;
             expect(typeof result).to.be('object');
             expect(Object.keys(result).length).to.be(0);
             done();
@@ -72,7 +72,7 @@ describe('lib/hmdajson', function() {
                     'end': 11
                 }
             };
-            var result = HMDAJson.parseLine(line_spec, line);
+            var result = HMDAJson.parseLine('', line_spec, line);
             expect(result.error).to.be('Line is not long enough to contain \'foo\'');
             done();
         });
@@ -93,7 +93,7 @@ describe('lib/hmdajson', function() {
                     'end': 10
                 }
             };
-            var result = HMDAJson.parseLine(line_spec, line).record;
+            var result = HMDAJson.parseLine('', line_spec, line).record;
             expect(result).to.have.property('one');
             expect(result.one).to.be.equal('1');
             expect(result).to.have.property('middle');
@@ -112,7 +112,7 @@ describe('lib/hmdajson', function() {
                     'dataType': 'N'
                 }
             };
-            var result = HMDAJson.parseLine(line_spec, line);
+            var result = HMDAJson.parseLine('', line_spec, line);
             expect(result.error).to.be('\'foo\' must be a number');
             done();
         });


### PR DESCRIPTION
After doing some research (http://www.html5rocks.com/en/tutorials/speed/v8/ and http://www.developerknowhow.com/why-the-v8-javascript-engine-is-so-good/), it looks like the way we were creating the hmdaFile data was creating a lot of unnecessary hidden classes because we assign the properties on the fly.  After converting the LoanApplicationRegister to using a prototype function instead, I saw pretty dramatic reduction of memory in Chrome (for bankofthewest, 52MB heap size using existing vs. 30.9MB using prototypes.  I was unable to test on Firefox, because I can't install firefox on my cfpb laptop, but I imagine SpiderMonkey does some optimization like V8.  I ran it through the timing harness and didn't see any reduction of speed, so since this is a small lift and doesn't really require much refactoring, set it to create a prototype function based off the rule spec.