### PR TITLE
Apply a bit of safety to promise-http-get

### DIFF
--- a/lib/promise-http-get.js
+++ b/lib/promise-http-get.js
@@ -11,17 +11,27 @@ var request = function(url) {
       deferred.reject(new Error('The URL/path must be a string.'));
     }
 
-    var body = '';
     http.get(url, function(res) {
+        var chunks = [];
+
         if (res.statusCode >= 300) {
             deferred.reject(new Error('Server responded with status code '+ res.statusCode+' for url ' + url));
         }
 
         res.on('data', function(chunk) {
-            body += chunk;
+            chunks[chunks.length] = chunk;
         });
 
         res.on('end', function() {
+            // The UTF8 byte order mark
+            // Strip this value out, can break JSON.parse().
+            if (chunks[0].length > 0 && chunks[0][0] === '\uFEFF') {
+                chunks[0] = chunks[0].substring(1);
+            }
+            var body = '';
+            for (var i = 0; i < chunks.length; i++) {
+                body += chunks[i];
+            }
             deferred.resolve(body);
         });
 


### PR DESCRIPTION
Solve some issue surrounding building up the response body during API calls, with around the same performance: http://jsperf.com/string-concat-join-mak