### PR TITLE
Move rule parsing out of execRule

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1645,17 +1645,3 @@ var accumulateResult = function(ifResult, thenResult) {
   return (typeof module !== 'undefined' && module.exports &&
     typeof window === 'undefined') ? global : window;
 }())));
-    .then(function() {
-            if (DEBUG) {
-                console.timeEnd('time to run special rules');
-            }
-        })
-        .catch(function(err) {
-            return resolveError(err);
-        });
-    };
-
-}.call((function() {
-  return (typeof module !== 'undefined' && module.exports &&
-    typeof window === 'undefined') ? global : window;
-}())));

--- a/engine.js
+++ b/engine.js
@@ -43,7 +43,7 @@ var retrieveProps = function(error, line, properties) {
     }
 };
 
-var getRuleFunc = function(rule, currentEngine) {
+var getParsedRule = function(rule, currentEngine) {
     var result = {
         argIndex: 0,
         args: [],
@@ -672,9 +672,9 @@ var accumulateResult = function(ifResult, thenResult) {
             condid = '- compareNumEntriesSingleCond';
         }
 
-        var parsedResult = getRuleFunc(rule, currentEngine);
-        var functionBody = parsedResult[0];
-        var result = parsedResult[1];
+        var parsedRule = getParsedRule(rule, currentEngine);
+        var functionBody = parsedRule[0];
+        var result = parsedRule[1];
 
         return Promise.map(loanApplicationRegisters, function(lar) {
             return currentEngine.execParsedRule(lar, functionBody, result, ruleid)
@@ -717,12 +717,12 @@ var accumulateResult = function(ifResult, thenResult) {
             condid = '- compareNumEntriesCond';
         }
 
-        var parsedResult = getRuleFunc(ruleA, currentEngine);
-        var functionBodyA = parsedResult[0];
-        var resultA = parsedResult[1];
-        parsedResult = getRuleFunc(ruleB, currentEngine);
-        var functionBodyB = parsedResult[0];
-        var resultB = parsedResult[1];
+        var parsedRule = getParsedRule(ruleA, currentEngine);
+        var functionBodyA = parsedRule[0];
+        var resultA = parsedRule[1];
+        parsedRule = getParsedRule(ruleB, currentEngine);
+        var functionBodyB = parsedRule[0];
+        var resultB = parsedRule[1];
 
         return Promise.map(loanApplicationRegisters, function(lar) {
             return currentEngine.execParsedRule(lar, functionBodyA, resultA, ruleAid)
@@ -1453,7 +1453,7 @@ var accumulateResult = function(ifResult, thenResult) {
     };
 
     HMDAEngine.execRule = function(topLevelObj, rule, ruleid) {
-        var parserResult = getRuleFunc(rule, this);
+        var parserResult = getParsedRule(rule, this);
         var functionBody = parserResult[0];
         var result = parserResult[1];
         // var result = {
@@ -1539,9 +1539,9 @@ var accumulateResult = function(ifResult, thenResult) {
                 'scope': scope,
                 'editType': editType
             };
-            var parsedResult = getRuleFunc(currentRule.rule, currentEngine);
-            args.functionBody = parsedResult[0];
-            args.result = parsedResult[1];
+            var parsedRule = getParsedRule(currentRule.rule, currentEngine);
+            args.functionBody = parsedRule[0];
+            args.result = parsedRule[1];
 
             if (_.isArray(topLevelObj)) {
                 return Promise.map(topLevelObj, function(currentTopLevelObj) {

--- a/engine.js
+++ b/engine.js
@@ -1456,21 +1456,6 @@ var accumulateResult = function(ifResult, thenResult) {
         var parserResult = getParsedRule(rule, this);
         var functionBody = parserResult[0];
         var result = parserResult[1];
-        // var result = {
-        //     argIndex: 0,
-        //     args: [],
-        //     funcs: [],
-        //     spreads: [],
-        //     body: '',
-        //     properties: {}
-        // };
-
-        // this.parseRule(rule, result);
-        // var functionBody = 'return Promise.join(';
-        // functionBody += result.funcs.join(',');
-        // functionBody += ', function(';
-        // functionBody += result.spreads.join(',');
-        // functionBody += ') { return ' + result.body + ' });';
 
         return this.execParsedRule(topLevelObj, functionBody, result, ruleid);        
     };

--- a/engine.js
+++ b/engine.js
@@ -672,8 +672,12 @@ var accumulateResult = function(ifResult, thenResult) {
             condid = '- compareNumEntriesSingleCond';
         }
 
+        var parsedResult = getRuleFunc(rule, currentEngine);
+        var functionBody = parsedResult[0];
+        var result = parsedResult[1];
+
         return Promise.map(loanApplicationRegisters, function(lar) {
-            return currentEngine.execRule(lar, rule, ruleid)
+            return currentEngine.execParsedRule(lar, functionBody, result, ruleid)
             .then(function(result) {
                 if (result.length === 0) {
                     count += 1;
@@ -713,13 +717,20 @@ var accumulateResult = function(ifResult, thenResult) {
             condid = '- compareNumEntriesCond';
         }
 
+        var parsedResult = getRuleFunc(ruleA, currentEngine);
+        var functionBodyA = parsedResult[0];
+        var resultA = parsedResult[1];
+        parsedResult = getRuleFunc(ruleB, currentEngine);
+        var functionBodyB = parsedResult[0];
+        var resultB = parsedResult[1];
+
         return Promise.map(loanApplicationRegisters, function(lar) {
-            return currentEngine.execRule(lar, ruleA, ruleAid)
+            return currentEngine.execParsedRule(lar, functionBodyA, resultA, ruleAid)
             .then(function(result) {
                 if (result.length === 0) {
                     countA += 1;
                 }
-                return currentEngine.execRule(lar, ruleB, ruleBid)
+                return currentEngine.execParsedRule(lar, functionBodyB, resultB, ruleBid)
                 .then(function(result) {
                     if (result.length === 0) {
                         countB += 1;

--- a/test/engineSpec.js
+++ b/test/engineSpec.js
@@ -3326,7 +3326,7 @@ describe('Engine', function() {
             };
             var rewiredEngine = rewire('../engine');
             var getParsedRule = rewiredEngine.__get__('getParsedRule');
-            var result = getParsedRule(rule, engine);
+            var result = getParsedRule.apply(engine, [rule]);
             var parsedRule = {
                 argIndex: 1,
                 args: ['foo'],

--- a/test/engineSpec.js
+++ b/test/engineSpec.js
@@ -1487,10 +1487,10 @@ describe('Engine', function() {
                         engine.setUseLocalDB(false)
                         .then(function() {
                             done();
-                        })
+                        });
                     });
                 });
-            })
+            });
         });
 
         it('should return false when we use local data and the result is false', function(done) {
@@ -3315,6 +3315,32 @@ describe('Engine', function() {
                 expect(result[1].totalRefinance).to.be(2);
                 done();
             });
+        });
+    });
+
+    describe('getRuleFunc', function() {
+        it('should return the function text and parsed rule for a given rule', function(done) {
+            var rule = {
+                'property': 'foo',
+                'condition': 'is_true'
+            };
+            var rewiredEngine = rewire('../engine');
+            var getRuleFunc = rewiredEngine.__get__('getRuleFunc');
+            var result = getRuleFunc(rule, engine);
+            var parseResult = {
+                argIndex: 1,
+                args: ['foo'],
+                funcs: ['this.is_true(arguments[0])'],
+                spreads: ['promise0result'],
+                body: 'promise0result',
+                properties: {foo: true}
+            };
+
+            expect(result[0]).to.be('return Promise.join(this.is_true(arguments[0]), function(promise0result) { return promise0result });');
+            expect(_.isEqual(result[1], parseResult)).to.be.true();
+
+            result = getRuleFunc(rule, engine);
+            done();
         });
     });
 });

--- a/test/engineSpec.js
+++ b/test/engineSpec.js
@@ -3325,9 +3325,9 @@ describe('Engine', function() {
                 'condition': 'is_true'
             };
             var rewiredEngine = rewire('../engine');
-            var getRuleFunc = rewiredEngine.__get__('getRuleFunc');
-            var result = getRuleFunc(rule, engine);
-            var parseResult = {
+            var getParsedRule = rewiredEngine.__get__('getParsedRule');
+            var result = getParsedRule(rule, engine);
+            var parsedRule = {
                 argIndex: 1,
                 args: ['foo'],
                 funcs: ['this.is_true(arguments[0])'],
@@ -3337,9 +3337,7 @@ describe('Engine', function() {
             };
 
             expect(result[0]).to.be('return Promise.join(this.is_true(arguments[0]), function(promise0result) { return promise0result });');
-            expect(_.isEqual(result[1], parseResult)).to.be.true();
-
-            result = getRuleFunc(rule, engine);
+            expect(_.isEqual(result[1], parsedRule)).to.be.true();
             done();
         });
     });


### PR DESCRIPTION
Move rule parsing out of execRule for rules that run on every lar.
Produces roughly a 25% performance improvement when running a large file locally on the harness.