### PR TITLE
Use node-coveralls directly instead of grunt-coveralls

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,6 +58,7 @@ module.exports = function (grunt) {
                 src: 'test', // the folder name for the tests
                 options: {
                     recursive: true,
+                    coverage: true, // emit the coverage event
                     //quiet: true,
                     excludes: [],
                     mochaOptions: [
@@ -77,12 +78,6 @@ module.exports = function (grunt) {
             }
         },
 
-        coveralls: {
-            options: {
-                src: 'coverage/lcov.info'
-            }
-        }
-
     });
 
 
@@ -93,12 +88,20 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-env');
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-release');
-    grunt.loadNpmTasks('grunt-coveralls');
+
+    // handle coverage event by sending data to coveralls
+    grunt.event.on('coverage', function(lcov, done){
+        require('coveralls').handleInput(lcov, function(err){
+            if (err) {
+                return done(err);
+            }
+            done();
+        });
+    });
 
     // Register group tasks
     grunt.registerTask('clean_all', [ 'clean:node_modules', 'clean:coverage', 'npm_install' ]);
     grunt.registerTask('test', ['env:test', 'clean:coverage', 'jshint', 'mocha_istanbul']);
-    grunt.registerTask('travis-coverage', ['test', 'coveralls']);
     grunt.registerTask('coverage', ['test', 'open_coverage' ]);
 
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "BRIJ compliant rules engine for HMDA data",
   "main": "engine.js",
   "scripts": {
-    "test": "grunt travis-coverage"
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",
@@ -17,11 +17,11 @@
   },
   "homepage": "https://github.com/cfpb/hmda-rule-engine",
   "devDependencies": {
+    "coveralls": "^2.11.2",
     "grunt": "^0.4.5",
     "grunt-config-dir": "^0.3.2",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-jshint": "^0.10.0",
-    "grunt-coveralls": "^1.0.0",
     "grunt-develop": "^0.4.0",
     "grunt-env": "~0.4.1",
     "grunt-mocha-istanbul": "^1.4.1",


### PR DESCRIPTION
Use the `coverage` event emitted by `mocha_istanbul` in grunt