### PR TITLE
added a filter to remove some msas based off agencyCode and MSA Branches data

### DIFF
--- a/test/testdata/loans-to-total.json
+++ b/test/testdata/loans-to-total.json
@@ -3,7 +3,7 @@
         "transmittalSheet": {
             "recordID": "1",
             "respondentID": "0123456789",
-            "agencyCode": "9",
+            "agencyCode": "7",
             "timestamp": "201301171330",
             "filler": "",
             "activityYear": "2013",


### PR DESCRIPTION
Fixes cfpb/hmda-pilot#296.  Includes adding a new getMSABranches convenience function so we don't have call the API multiple times.  Adding the filter function after the collect didn't work because of some unresolved promises, so I added it before.  Only snag is groupBy produces key/value pairs and filter returns an array, so had to add a bit of ugliness to get the first item in the set and retrieve the msaCode from that.  