### PR TITLE
Refactor progress, so it just works against the rules as a whole

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -32,7 +32,6 @@ function Errors() {
 function Progress() {
     return {
         events: new EventEmitter(),
-        throttle: 0,
         count: 0,
         estimate: 0
     };

--- a/lib/engineCustomDataLookupConditions.js
+++ b/lib/engineCustomDataLookupConditions.js
@@ -376,14 +376,12 @@ var EngineCustomDataLookupConditions = (function() {
                     ], true)
                     .then(function(result) {
                         pushMSA(element, result);
-                        this.postTaskCompletedMessage();
                         return;
                     }.bind(this));
                 } else {
                     return this.apiGET('isValidCensusCombination', [element.fipsState, element.fipsCounty, element.censusTract])
                     .then(function(response) {
                         pushMSA(element, utils.jsonParseResponse(response));
-                        this.postTaskCompletedMessage();
                         return;
                     }.bind(this));
                 }
@@ -415,11 +413,8 @@ var EngineCustomDataLookupConditions = (function() {
                                     invalidMSAs.push(element.metroArea);
                                 }
                             }
-                            this.postTaskCompletedMessage();
                         }.bind(this),  {concurrency: this._CONCURRENT_LARS});
                     }.bind(this));
-                } else {
-                    this.postTaskCompletedMessage(lars.length);
                 }
             }.bind(this))
             .then(function() {

--- a/lib/ruleParseAndExec.js
+++ b/lib/ruleParseAndExec.js
@@ -141,7 +141,6 @@ var RuleParseAndExec = (function() {
                 if (ruleid) {
                     console.timeEnd('    ' + ruleid);
                 }
-                this.postTaskCompletedMessage();
                 if (funcResult === true) {
                     return [];
                 } else if (topLevelObj.hmdaFile) {
@@ -225,6 +224,7 @@ var RuleParseAndExec = (function() {
                     return this.getExecRulePromise(args);
                 }.bind(this), { concurrency: this._CONCURRENT_LARS })
                 .then(function() {
+                    this.postTaskCompletedMessage();
                     /* istanbul ignore if */
                     if (this.getDebug() > 0) {
                         console.timeEnd('    ' + currentRule.id + ' - ' + scope);

--- a/lib/ruleProgress.js
+++ b/lib/ruleProgress.js
@@ -14,45 +14,24 @@ var RuleProgress = (function() {
          * @param  {type}  the type of HMDA edits (syntactical, validity, etc.)
          */
         this.calcEstimatedTasks = function (year, scopeList, type) {
-            var scopeLen = scopeList.length,
-                larsLen = this.getHmdaJson().hmdaFile.loanApplicationRegisters.length;
-
+            var scopeLen = scopeList.length;
             for (var i=0; i < scopeLen; i++) {
                 var scope = scopeList[i],
                     rules = hmdaRuleSpec.getEdits(year, scope, type),
                     rulesLen = rules.length;
-
-                if (scope==='lar' || type==='special') {
-                    this.progress.estimate += larsLen * rulesLen;
-                } else if (type==='macro') {
-                    // apply 99% confidence interval based off normal distribution curve calculated from 5 sample banks
-                    var upperbound = 1.69;
-                    this.progress.estimate += Math.floor(larsLen * rulesLen * upperbound);
-                } else {
-                    this.progress.estimate += rulesLen;
-                }
+                this.progress.estimate += rulesLen;
             }
-            this.progress.throttle = Math.floor(this.progress.estimate/100);
             this.progress.count = 0;
         };
 
 
         /**
          * sends a notification message with the percentage of tasks completed/estimate
-         * @param  {count}  optional parameter indicating a large jump in tasks completed
          */
-        this.postTaskCompletedMessage = function(count) {
-            if (count === undefined) {
-                this.progress.count ++;
-            } else {
-                this.progress.count += count;
-            }
-            if (this.progress.count % this.progress.throttle === 0) {
-                this.progress.events.emit('progressStep',
-                    Math.floor(this.progress.count/this.progress.throttle));
-                return;
-            }
-            return false;
+        this.postTaskCompletedMessage = function() {
+            this.progress.events.emit('progressStep',
+                    Math.floor(++this.progress.count/this.progress.estimate*100));
+            return;
         };
 
         return this;

--- a/test/lib/ruleProgressSpec.js
+++ b/test/lib/ruleProgressSpec.js
@@ -15,7 +15,6 @@ var EngineCustomConditions = require('../../lib/engineCustomConditions'),
         this._HMDA_JSON = {};
         this.progress = {
             events: {},
-            throttle: 0,
             count: 0,
             estimate: 0
         };
@@ -41,37 +40,47 @@ describe('RuleProgress', function() {
         done();
     });
 
-    it('should send out an event when calling postTaskCompletedMessage and count is correct', function(done) {
+    beforeEach(function(done) {
         engine.getProgress().count = 0;
-        engine.getProgress().throttle = 1;
+        engine.getProgress().estimate = 0;
+        done();
+    });
+
+    it('should calcuate a percent of 100', function(done) {
+        engine.getProgress().count = 0;
+        engine.getProgress().estimate = 1;
         engine.getProgress().events = new EventEmitter();
 
         engine.getProgress().events.on('progressStep', function(percent) {
-            expect(percent).to.be(1);
+            expect(percent).to.be(100);
             done();
         });
 
         engine.postTaskCompletedMessage();
     });
 
-    it('should send out an event with a larger percent if postTaskCompletedMessage is passed a count parameter', function(done) {
+    it('should calcuate a percent of 75', function(done) {
         engine.getProgress().count = 5;
-        engine.getProgress().throttle = 1;
+        engine.getProgress().estimate = 8;
         engine.getProgress().events = new EventEmitter();
 
         engine.getProgress().events.on('progressStep', function(percent) {
-            expect(percent).to.be(10);
+            expect(percent).to.be(75);
             done();
         });
-
-        engine.postTaskCompletedMessage(5);
+        engine.postTaskCompletedMessage();
     });
 
-    it('should not send out an event calling postTaskCompletedMessage with count not equal to throttle', function(done) {
-        engine.getProgress().count = 0;
-        engine.getProgress().throttle = 2;
-        expect(engine.postTaskCompletedMessage()).to.be(false);
-        done();
+    it('should calcuate a percent of 50', function(done) {
+        engine.getProgress().count = 1;
+        engine.getProgress().estimate = 4;
+        engine.getProgress().events = new EventEmitter();
+
+        engine.getProgress().events.on('progressStep', function(percent) {
+            expect(percent).to.be(50);
+            done();
+        });
+        engine.postTaskCompletedMessage();
     });
 
     it('should calculate estimated tasks for transmittal sheet scope', function(done) {
@@ -85,7 +94,7 @@ describe('RuleProgress', function() {
         engine.clearProgress();
         engine._HMDA_JSON = JSON.parse(JSON.stringify(require('../testdata/complete.json')));
         engine.calcEstimatedTasks('2013',['lar'],'validity');
-        expect(engine.getProgress().estimate).to.be(189);
+        expect(engine.getProgress().estimate).to.be(63);
         done();
     });
 
@@ -93,7 +102,7 @@ describe('RuleProgress', function() {
         engine.clearProgress();
         engine._HMDA_JSON = JSON.parse(JSON.stringify(require('../testdata/complete.json')));
         engine.calcEstimatedTasks('2013',['hmda'],'macro');
-        expect(engine.getProgress().estimate).to.be(167);
+        expect(engine.getProgress().estimate).to.be(33);
         done();
     });
 


### PR DESCRIPTION
Because the rules are CPU bound, events emitted while inside the rule processing (emitted for each LAR) don't get emitted efficiently. Switch the events so that the percentage is based on all the rules being run during a certain stage in the process rather than all the rules + all the lars. This means we don't have to do a magic number calculation for the macros either.

Because I've yanked so much code in this refactor, coverage numbers will go down a bit.