### PR TITLE
Allow the reference of transmittal sheet properties in lar processing

### DIFF
--- a/lib/csvProcessor.js
+++ b/lib/csvProcessor.js
@@ -98,6 +98,7 @@ CSVProcessor.prototype.individual = function() {
                 }
                 contextList.push(this.fileSpec);
                 if (errors[id].scope === 'hmda') {
+                    contextList.push(this.fileSpec.hmdaFile);
                     contextList.push(this.fileSpec.hmdaFile.transmittalSheet);
                     contextList.push(this.fileSpec.hmdaFile.loanApplicationRegister);
                 }

--- a/lib/engineCustomConditions.js
+++ b/lib/engineCustomConditions.js
@@ -62,7 +62,7 @@ var EngineCustomConditions = (function() {
             var errors = utils.handleArrayErrors(hmdaFile, records, ['actionDate']);
 
             for (var j = 0; j < errors.length; j++) {
-                errors[j].properties.activityYear = activityYear;
+                errors[j].properties['transmittalSheet.activityYear'] = activityYear;
             }
 
             return errors;

--- a/test/testdata/errors-syntactical.json
+++ b/test/testdata/errors-syntactical.json
@@ -35,7 +35,7 @@
                     "lineNumber": "2",
                     "properties": {
                         "actionDate": "20130119",
-                        "activityYear": "2014"
+                        "transmittalSheet.activityYear": "2014"
                     },
                     "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
@@ -43,7 +43,7 @@
                     "lineNumber": "3",
                     "properties": {
                         "actionDate": "20130119",
-                        "activityYear": "2014"
+                        "transmittalSheet.activityYear": "2014"
                     },
                     "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 },
@@ -51,7 +51,7 @@
                     "lineNumber": "4",
                     "properties": {
                         "actionDate": "20130119",
-                        "activityYear": "2014"
+                        "transmittalSheet.activityYear": "2014"
                     },
                     "loanNumber": "ABCDEFGHIJKLMNOPQRSTUVWXY"
                 }


### PR DESCRIPTION
This is half of the fix for cfpb/hmda-pilot#368. This is a situation where the scope is `hmda`, but the properties are not referencing one of either `lar` or `ts` but both. Since `lar` is the primary scope for the properties, allow referencing those `ts` properties using dot notation.